### PR TITLE
Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,30 @@ easyBEATS is a project started to make the installation of Beats packages faster
 
 The instructions are here so that you can compile Beats on your own.  If you would prefer something a bit easier that doesn't require compiling source code, visit the repo from a contributyor RaoulDuke [Beats-Pi repo](https://github.com/RaoulDuke-Esq/Beats-Pi) for some pre-baked Beats that you can install via apt.
 
+## Export
+
+The **export branch** changes the default behaviour to export beat installation files. There are a couple parameters added:
+
+```
+EXPORT_DIR="beat-export" #this directory will be created in /home/pi
+EXPORT_INSTALL=true #set to false if you do not want to export
+```
+
+### Default
+
+The default values are set according CI purposes.
+
+UPDATE_SYSTEM=true
+INSTALL_DEPS=true
+USE_SWAP=false
+WORKING_DIR="beat-factory"
+BEAT_VERSION="v7.11.0"
+BEAT_NAME=( metricbeat )
+INSTALL_LOCAL=true
+CLEAN_UP=true
+EXPORT_DIR="beat-export"
+EXPORT_INSTALL=true
+
 ## How To Use
 
 ### Clone the repo

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 easyBEATS is a project started to make the installation of Beats packages faster and easier for Ubuntu, Mac, and even Raspberry Pi (ARM architecture). The focus was for Rasperry Pi since Elastic does not have a supported release on ARM architecture.  easyBEATS also resolves issues related to the outdated golang-go package in the RPi apt repo which prevents the successful installation of Beats newer than v7.3.2.  The current version of the script will let you install one or multiple Beats at any version.
 
-The instructions are here so that you can compile Beats on your own.  If you would prefer something a bit easier that doesn't require compiling source code, visit the repo from a contributyor RaoulDuke [Beats-Pi repo](https://github.com/RaoulDuke-Esq/Beats-Pi) for some pre-baked Beats that you can install via apt.
-
 ## Export
 
 The **export branch** changes the default behaviour to export beat installation files. There are a couple parameters added:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ EXPORT_DIR="beat-export"
 EXPORT_INSTALL=true
 ```
 
+### Installing from export
+
+The installation script comes together with the exported files. Copy the $EXPORT_DIR to the proper $HOME, and run the install script after making it executable:
+
+```
+cd $HOME/${EXPORT_DIR}
+sudo chmod 755 installBEATS
+./installBEATS
+
+```
+
 ## How To Use
 
 ### Clone the repo

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ EXPORT_INSTALL=true #set to false if you do not want to export
 
 The default values are set according CI purposes.
 
+```
 UPDATE_SYSTEM=true
 INSTALL_DEPS=true
 USE_SWAP=false
@@ -30,6 +31,7 @@ INSTALL_LOCAL=true
 CLEAN_UP=true
 EXPORT_DIR="beat-export"
 EXPORT_INSTALL=true
+```
 
 ## How To Use
 

--- a/easyBEATS
+++ b/easyBEATS
@@ -6,11 +6,13 @@ INSTALL_DEPS=true #change to false if you have already run this script successfu
 USE_SWAP=false #change to fales if you're using a Pi4 with 2GB of RAM or more
 WORKING_DIR="beat-factory" #this directory will be created in /home/pi
 #visit https://github.com/elastic/beats/releases to find other version numbers and commit numbers
-BEAT_VERSION="v7.11.0" #the version tag name or commit id of the Beats release you want to use
+BEAT_VERSION="v7.14.1" #the version tag name or commit id of the Beats release you want to use
 #add as many beats as you want to BEAT_NAME separated by a space
-BEAT_NAME=( metricbeat filebeat ) #metricbeat filebeat packetbeat auditbeat heartbeat
+BEAT_NAME=( metricbeat ) #metricbeat filebeat packetbeat auditbeat heartbeat
 INSTALL_LOCAL=true #set to false if you only want to compile without installing
-CLEAN_UP=true #set to false if you want to keep the source files on your Pi
+CLEAN_UP=false #set to false if you want to keep the source files on your Pi
+EXPORT_DIR="beat-export" #this directory will be created in /home/pi
+EXPORT_INSTALL=true #set to false if you only want to compile without exporting
 
 function clean_up {
   sudo rm -rf $HOME/${WORKING_DIR}
@@ -114,6 +116,11 @@ function create_working_directory {
   echo "Working directory created"
 }
 
+function create_export_directory {
+  mkdir -p $HOME/${EXPORT_DIR};
+  echo "Export directory created"
+}
+
 function update_system {
   sudo DEBIAN_FRONTEND=noninteractive apt-get -yq update > /dev/null
   sudo DEBIAN_FRONTEND=noninteractive apt-get -yq upgrade > /dev/null
@@ -161,6 +168,50 @@ function install_local {
     sudo chown -R root:root /usr/share/${beat}/*;
     sudo /bin/systemctl daemon-reload;
     sudo systemctl enable ${beat};
+  done
+}
+
+function export_install {
+  for beat in "${BEAT_NAME[@]}";
+  do
+    if [ ! -d $HOME/${EXPORT_DIR}/usr/share/$beat ];
+    then
+      echo "Exporting /usr/share/$beat directory..."
+      sudo mkdir -p $HOME/${EXPORT_DIR}/usr/share/$beat/bin;
+    fi
+
+    if  [ ! -d $HOME/${EXPORT_DIR}/etc/$beat ];
+    then
+      echo "Exporting /etc/$beat directory..."
+      sudo mkdir -p $HOME/${EXPORT_DIR}/etc/$beat;
+    fi
+
+    if [ ! -d $HOME/${EXPORT_DIR}/var/lib/$beat ];
+    then
+      echo "Exporting /var/lib/$beat directory..."
+      sudo mkdir -p $HOME/${EXPORT_DIR}/var/lib/$beat
+    fi
+
+    echo "Installing $beat locally..."
+    sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat} $HOME/${EXPORT_DIR}/usr/share/${beat}/bin
+    sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat}.reference.yml $HOME/${EXPORT_DIR}/etc/${beat}
+    sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat}.yml $HOME/${EXPORT_DIR}/etc/${beat}
+
+    if [ $beat = "filebeat" ] || [ $beat = "metricbeat" ];
+    then
+      sudo cp -R $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/module $HOME/${EXPORT_DIR}/usr/share/${beat}
+      sudo cp -R $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/modules.d/ $HOME/${EXPORT_DIR}/etc/${beat}
+    fi
+
+    sudo cp $HOME/easyBEATS/services/${beat}.service $HOME/${EXPORT_DIR}/lib/systemd/system
+
+
+
+    sudo chmod -R 755 $HOME/${EXPORT_DIR}/etc/${beat}/;
+    sudo chown -R root:root $HOME/${EXPORT_DIR}/etc/${beat};
+    sudo chown -R root:root $HOME/${EXPORT_DIR}/usr/share/${beat}/*;
+    #sudo /bin/systemctl daemon-reload;
+    #sudo systemctl enable ${beat};
   done
 }
 
@@ -227,6 +278,22 @@ then
   echo "Installing on your local system..."
   install_local
 fi
+
+echo "---------------------------------------------------------------"
+
+if [ $EXPORT_INSTALL = true ];
+then
+  if [ ! -d $HOME/${EXPORT_DIR} ];
+  then
+    create_export_directory
+  else
+    echo "Export directory already exists"
+  fi
+  echo "Exporting to your local system..."
+  export_install
+fi
+
+echo "---------------------------------------------------------------"
 
 if [ $CLEAN_UP = true ];
 then

--- a/easyBEATS
+++ b/easyBEATS
@@ -194,7 +194,7 @@ function export_install {
 
     if [ ! -d $HOME/${EXPORT_DIR}/lib/systemd/system ];
     then
-      echo "Exporting lib/systemd/system directory..."
+      echo "Exporting /lib/systemd/system directory..."
       sudo mkdir -p $HOME/${EXPORT_DIR}/lib/systemd/system
     fi
 

--- a/easyBEATS
+++ b/easyBEATS
@@ -118,7 +118,6 @@ function create_working_directory {
 
 function create_export_directory {
   mkdir -p $HOME/${EXPORT_DIR};
-  mkdir -p $HOME/${EXPORT_DIR}/lib/systemd/system;
   echo "Export directory created"
 }
 
@@ -193,6 +192,12 @@ function export_install {
       sudo mkdir -p $HOME/${EXPORT_DIR}/var/lib/$beat
     fi
 
+    if [ ! -d $HOME/${EXPORT_DIR}/lib/systemd/system ];
+    then
+      echo "Exporting lib/systemd/system directory..."
+      sudo mkdir -p $HOME/${EXPORT_DIR}/lib/systemd/system
+    fi
+
     echo "Installing $beat locally..."
     sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat} $HOME/${EXPORT_DIR}/usr/share/${beat}/bin
     sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat}.reference.yml $HOME/${EXPORT_DIR}/etc/${beat}
@@ -205,8 +210,6 @@ function export_install {
     fi
 
     sudo cp $HOME/easyBEATS/services/${beat}.service $HOME/${EXPORT_DIR}/lib/systemd/system
-
-
 
     sudo chmod -R 755 $HOME/${EXPORT_DIR}/etc/${beat}/;
     sudo chown -R root:root $HOME/${EXPORT_DIR}/etc/${beat};
@@ -290,7 +293,7 @@ then
   else
     echo "Export directory already exists"
   fi
-  echo "Exporting to your local system..."
+  echo "Exporting to local system..."
   export_install
 fi
 

--- a/easyBEATS
+++ b/easyBEATS
@@ -6,13 +6,13 @@ INSTALL_DEPS=true #change to false if you have already run this script successfu
 USE_SWAP=false #change to fales if you're using a Pi4 with 2GB of RAM or more
 WORKING_DIR="beat-factory" #this directory will be created in /home/pi
 #visit https://github.com/elastic/beats/releases to find other version numbers and commit numbers
-BEAT_VERSION="v7.14.1" #the version tag name or commit id of the Beats release you want to use
+BEAT_VERSION="v7.11.0" #the version tag name or commit id of the Beats release you want to use
 #add as many beats as you want to BEAT_NAME separated by a space
 BEAT_NAME=( metricbeat ) #metricbeat filebeat packetbeat auditbeat heartbeat
 INSTALL_LOCAL=true #set to false if you only want to compile without installing
-CLEAN_UP=false #set to false if you want to keep the source files on your Pi
+CLEAN_UP=true #set to false if you want to keep the source files on your Pi
 EXPORT_DIR="beat-export" #this directory will be created in /home/pi
-EXPORT_INSTALL=true #set to false if you only want to compile without exporting
+EXPORT_INSTALL=true #set to false if you do not want to export
 
 function clean_up {
   sudo rm -rf $HOME/${WORKING_DIR}
@@ -118,6 +118,7 @@ function create_working_directory {
 
 function create_export_directory {
   mkdir -p $HOME/${EXPORT_DIR};
+  mkdir -p $HOME/${EXPORT_DIR}/lib/systemd/system;
   echo "Export directory created"
 }
 
@@ -149,7 +150,7 @@ function install_local {
     fi
 
     echo "Installing $beat locally..."
-    sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat} /usr/share/${beat}/bin
+    sudo cp -f $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat} /usr/share/${beat}/bin
     sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat}.reference.yml /etc/${beat}
     sudo cp $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/${beat}.yml /etc/${beat}
 

--- a/easyBEATS
+++ b/easyBEATS
@@ -119,6 +119,8 @@ function create_working_directory {
 function create_export_directory {
   mkdir -p $HOME/${EXPORT_DIR};
   echo "Export directory created"
+  sudo cp $HOME/easyBEATS/installBEATS $HOME/${EXPORT_DIR};
+  sudo chmod 755 $HOME/${EXPORT_DIR}/installBEATS
 }
 
 function update_system {

--- a/easyBEATS
+++ b/easyBEATS
@@ -197,7 +197,7 @@ function export_install {
     if [ ! -d $HOME/${EXPORT_DIR}/lib/systemd/system ];
     then
       echo "Exporting /lib/systemd/system directory..."
-      sudo mkdir -p $HOME/${EXPORT_DIR}/lib/systemd/system
+      sudo mkdir -p $HOME/${EXPORT_DIR}/usr/lib/systemd/system
     fi
 
     echo "Installing $beat locally..."
@@ -211,7 +211,7 @@ function export_install {
       sudo cp -R $HOME/${WORKING_DIR}/src/github.com/elastic/beats/${beat}/modules.d/ $HOME/${EXPORT_DIR}/etc/${beat}
     fi
 
-    sudo cp $HOME/easyBEATS/services/${beat}.service $HOME/${EXPORT_DIR}/lib/systemd/system
+    sudo cp $HOME/easyBEATS/services/${beat}.service $HOME/${EXPORT_DIR}/usr/lib/systemd/system
 
     sudo chmod -R 755 $HOME/${EXPORT_DIR}/etc/${beat}/;
     sudo chown -R root:root $HOME/${EXPORT_DIR}/etc/${beat};

--- a/installBEATS
+++ b/installBEATS
@@ -18,7 +18,7 @@ function install_local {
   do
     echo "Installing $beat locally..."    
 
-    #sudo cp -f $HOME/${EXPORT_DIR}/lib/systemd/system/${beat}.service /lib/systemd/system
+    #sudo cp -f $HOME/${EXPORT_DIR}/usr/lib/systemd/system/${beat}.service /usr/lib/systemd/system
 
     sudo chmod -R 755 /etc/${beat}/;
     sudo chown -R root:root /etc/${beat};

--- a/installBEATS
+++ b/installBEATS
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Script variables
+UPDATE_SYSTEM=true #change to false if you don't want to upgrade your whole system
+#add as many beats as you want to BEAT_NAME separated by a space
+BEAT_NAME=( metricbeat ) #metricbeat filebeat packetbeat auditbeat heartbeat
+EXPORT_DIR="beat-export" #this directory will be used from /home/pi
+
+function update_system {
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -yq update > /dev/null
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -yq upgrade > /dev/null
+  echo "System update complete"
+}
+
+function install_local {
+  sudo cp -pR $HOME/${EXPORT_DIR}/* /
+  for beat in "${BEAT_NAME[@]}";
+  do
+    echo "Installing $beat locally..."    
+
+    #sudo cp -f $HOME/${EXPORT_DIR}/lib/systemd/system/${beat}.service /lib/systemd/system
+
+    sudo chmod -R 755 /etc/${beat}/;
+    sudo chown -R root:root /etc/${beat};
+    sudo chown -R root:root /usr/share/${beat}/*;
+    sudo /bin/systemctl daemon-reload;
+    sudo systemctl enable ${beat};
+  done
+}
+
+echo "---------------------------------------------------------------"
+if [ $UPDATE_SYSTEM = true ];
+then
+  echo "Performing system update..."
+  update_system
+else
+  echo "Skipping system update"
+fi
+
+echo "---------------------------------------------------------------"
+
+
+echo "Installing on your local system..."
+install_local
+
+echo "---------------------------------------------------------------"
+
+echo "Complete"


### PR DESCRIPTION
## Export

The **export branch** changes the default behaviour to export beat installation files. There are a couple parameters added:

```
EXPORT_DIR="beat-export" #this directory will be created in /home/pi
EXPORT_INSTALL=true #set to false if you do not want to export
```

### Default

The default values are set according CI purposes.

```
UPDATE_SYSTEM=true
INSTALL_DEPS=true
USE_SWAP=false
WORKING_DIR="beat-factory"
BEAT_VERSION="v7.11.0"
BEAT_NAME=( metricbeat )
INSTALL_LOCAL=true
CLEAN_UP=true
EXPORT_DIR="beat-export"
EXPORT_INSTALL=true
```

### Installing from export

The installation script comes together with the exported files. Copy the $EXPORT_DIR to the proper $HOME, and run the install script after making it executable:

```
cd $HOME/${EXPORT_DIR}
sudo chmod 755 installBEATS
./installBEATS

```